### PR TITLE
fix(bookings): BookingDay list creation

### DIFF
--- a/src/routes/Host.ts
+++ b/src/routes/Host.ts
@@ -136,8 +136,9 @@ export const getBookings = async (token: string, hostId: number, week?: number):
     }
     const weekRange = getWeekRange(rawBooking.rsvWebDto[0].semaine, rawBooking.rsvWebDto[0].annee);
     const bookings = [];
-    const days = [];
     for (const rawBookingDto of rawBooking.rsvWebDto) {
+        const days = [];
+
         for (const rawDay of rawBookingDto.jours) {
             days.push(new BookingDay(
                 token,


### PR DESCRIPTION
The list of days should be built for each booking and not for all of them as it often leads bookings to have the same day multiple times, which is inconsistent.

This fixes the "strange" bug I was talking about on Papillon's Discord server. :+1: